### PR TITLE
Fix format-security build warning

### DIFF
--- a/ext/marisa/marisa-swig_wrap.cxx
+++ b/ext/marisa/marisa-swig_wrap.cxx
@@ -1402,7 +1402,7 @@ SWIG_Ruby_AppendOutput(VALUE target, VALUE o) {
 /* Error manipulation */
 
 #define SWIG_ErrorType(code)                            SWIG_Ruby_ErrorType(code)               
-#define SWIG_Error(code, msg)            		rb_raise(SWIG_Ruby_ErrorType(code), msg)
+#define SWIG_Error(code, msg)            		rb_raise(SWIG_Ruby_ErrorType(code), "%s", msg)
 #define SWIG_fail                        		goto fail				 
 
 


### PR DESCRIPTION
Trivial fix for format string build warning/error due to --Werror=format-security